### PR TITLE
build(pre-commit.yml): use default naming convention for test files i…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,6 @@ repos:
       - id: fix-byte-order-marker
       - id: mixed-line-ending
       - id: name-tests-test
-        args: [--pytest-test-first]
       - id: trailing-whitespace
         types: [python]
   - repo: local


### PR DESCRIPTION
…n pre-commit rule

use default naming convention for test files in pre-commit rule

[<teamwork_task_id>:<teamwork_task_name>](https://baselinequebec.teamwork.com/app/tasks/<teamwork_task_id>)

## Describe your changes

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have bumped the version if needed.
